### PR TITLE
Chore: react-icons 라이브러리 @react-icons/all-files로 대체

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
+        "@react-icons/all-files": "^4.1.0",
         "@tailwindcss/forms": "^0.5.7",
         "@types/lodash": "^4.14.200",
         "@types/node": "^20.9.0",
@@ -20,7 +21,6 @@
         "next": "14.0.1",
         "react": "^18",
         "react-dom": "^18",
-        "react-icons": "^4.11.0",
         "react-toastify": "^9.1.3",
         "recoil": "^0.7.7",
         "tailwindcss": "^3.3.5",
@@ -394,6 +394,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -3752,14 +3760,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
-      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
+    "@react-icons/all-files": "^4.1.0",
     "@tailwindcss/forms": "^0.5.7",
     "@types/lodash": "^4.14.200",
     "@types/node": "^20.9.0",
@@ -21,7 +22,6 @@
     "next": "14.0.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-icons": "^4.11.0",
     "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
     "tailwindcss": "^3.3.5",


### PR DESCRIPTION
## 🎋 작업중인 브랜치 
- feature-common


<br/>

## 💡 작업 내용 - #2 
> react-icons가 사이즈가 커서 성능에 지장을 주므로 @react-icons/all-files로 대체했습니다. 
참고 : https://east-star.tistory.com/36



<br/>

## 🔑  변경된 사항 
> package.json의 react-icons를 @react-icons/all-files로 대체했습니다. 



<br/>

## ✏️  비고 (선택)
> trustcrews-front-template 라이브러리에 쓰인 아이콘들은 react-icons아이콘들이라 템플릿을 작업시 가져와 사용할때 경로 수정이 필요합니다. 


<br/>

## ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
