### PR TITLE
feat:게시글 상세페이지 퍼블리싱 작업

### DIFF
--- a/public/images/pageback.svg
+++ b/public/images/pageback.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 9.625H5.26625L12.9525 1.93875L11 0L0 11L11 22L12.9387 20.0613L5.26625 12.375H22V9.625Z" fill="#686B6F"/>
+</svg>

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import PostDetail from "@/components/postDetail/PostDetail";
 
 const PostDetailPage = () => {
-  return <div>123</div>;
+  return <PostDetail />;
 };
 
 export default PostDetailPage;

--- a/src/components/main/postCard/PostCard.tsx
+++ b/src/components/main/postCard/PostCard.tsx
@@ -6,24 +6,24 @@ import Image from "next/image";
 const PostCard = () => {
   return (
     <>
-      <div className="p-3 flex-col w-[280px] h-[290px]  rounded-xl border-2 shadow-lg mobile:bg-white mobile:w-full mobile:shadow-none mobile:rounded-none mobile:border-none mobile:mt-3">
+      <div className="p-3 flex-col w-[280px] h-[300px]  rounded-xl border-2 shadow-lg mobile:bg-white mobile:w-full mobile:shadow-none mobile:rounded-none mobile:border-none mobile:mt-3">
         <div className="flex">
           <div className="font-bold text-base mr-3">trustcrews</div>
           <TrustGradeBadge size="xs" text="1등급" color="red" />
         </div>
-        <div className="flex mt-1">
+        <div className="flex mt-2">
           <div className="text-xs">2023.12.05 ~ </div>
           <div className="ml-2 text-xs">2023.01.10</div>
         </div>
         <div className="text-sm mt-2 font-bold text-grey800">
           주제 | 팀프로젝트 매칭 서비스 개발
         </div>
-        <div className="text-xl font-bold ">FE, BE 모집합니다</div>
-        <div className="flex gap-1 mt-2">
+        <div className="text-xl font-bold mt-2">FE, BE 모집합니다</div>
+        <div className="flex gap-1 mt-3">
           <PositionBadge size="xs" text="프론트엔드" />
           <PositionBadge size="xs" text="백엔드" />
         </div>
-        <div className="flex gap-1 border-b-2 pb-4 mt-6">
+        <div className="flex gap-1 border-b-2 pb-4 mt-5">
           <Image
             src="/images/javascript.svg"
             alt="자바스크립트"

--- a/src/components/main/posts/TechstackDropdown.tsx
+++ b/src/components/main/posts/TechstackDropdown.tsx
@@ -13,6 +13,17 @@ const TechstackDropdown = ({ onClick }: TechstackDropdownProps) => {
         <div className="text-lg text-grey800 mobile:text-sm">기술스택</div>
         <Image src={Arrow} alt="화살표버튼" />
       </div>
+      {/* <div className="absolute top-12">
+        <div className="p-2 flex flex-col w-[700px] h-[auto] mobile:w-[150px] mobile:h-[auto] border-2 rounded-3xl bg-white">
+          <ul className="flex ">
+            <li>프론트엔드</li>
+            <li>백엔드</li>
+            <li>모바일</li>
+            <li>기타</li>
+            <li>모두보기</li>
+          </ul>
+        </div>
+      </div> 작업중 */}
     </div>
   );
 };

--- a/src/components/postDetail/PostDetail.tsx
+++ b/src/components/postDetail/PostDetail.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import TitleSection from "./titleSection/TitleSection";
+import InfoSection from "./infoSection/InfoSection";
+import BodySection from "./bodySection/BodySection";
+import ButtonSection from "./buttonSection/ButtonSection";
+
+const PostDetail = () => {
+  return (
+    <div className="p-5 max-w-[900px] m-auto mt-20">
+      <TitleSection />
+      <InfoSection />
+      <BodySection />
+      <ButtonSection />
+    </div>
+  );
+};
+
+export default PostDetail;

--- a/src/components/postDetail/bodySection/BodySection.tsx
+++ b/src/components/postDetail/bodySection/BodySection.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const BodySection = () => {
+  return (
+    <div>
+      <div className="text-3xl font-bold mt-3 mobile:text-2xl">
+        프로젝트 소개
+      </div>
+      <div className="py-10 border-t-2 border-b-2 mt-10">
+        안녕하세요 프로젝트에 대한 설명글이 있는 공간입니다. 안녕하세요
+        프로젝트에 대한 설명글이 있는 공간입니다. 안녕하세요 프로젝트에 대한
+        설명글이 있는 공간입니다. 안녕하세요 프로젝트에 대한 설명글이 있는
+        공간입니다. 안녕하세요 프로젝트에 대한 설명글이 있는 공간입니다.
+      </div>
+    </div>
+  );
+};
+
+export default BodySection;

--- a/src/components/postDetail/buttonSection/ButtonSection.tsx
+++ b/src/components/postDetail/buttonSection/ButtonSection.tsx
@@ -1,0 +1,57 @@
+"use client";
+import Button from "@/components/ui/Button";
+import React, { useState } from "react";
+import Image from "next/image";
+import Arrow from "../../../../public/images/bottomarrow.svg";
+import { useRecoilValue } from "recoil";
+import { PostPositionState } from "@/store/PostStateStore";
+
+const ButtonSection = () => {
+  const [open, setOpen] = useState(false);
+  const Positions = useRecoilValue(PostPositionState);
+
+  return (
+    <div className="flex-col mb-40">
+      <div className="flex justify-center mt-5">
+        <div className="rounded-full bg-primary mobile:px-3.5 tablet:px-5 mobile:py-1.5 tablet:py-2 mobile:text-lg tablet:text-xl font-semibold text-white shadow-sm">
+          모집중
+        </div>
+      </div>
+      <div className="flex justify-center gap-5 mt-12">
+        <div>
+          <div className="relative" onClick={() => setOpen(!open)}>
+            <div className="px-4 flex justify-between w-[150px] h-[44px] mobile:w-[130px] mobile:h-[35px] items-center border-2 rounded-3xl cursor-pointer">
+              <div className="text-lg text-grey800 mobile:text-sm">포지션</div>
+              <Image src={Arrow} alt="화살표버튼" />
+            </div>
+            {open && (
+              <div className="absolute top-12">
+                <div className="p-2 flex flex-col w-[150px] h-[auto] mobile:w-[130px] mobile:h-[auto]  border-2 rounded-3xl bg-white">
+                  {Positions.map((position) => (
+                    <div
+                      key={position}
+                      className="p-2 text-lg mobile:text-sm font-bold text-grey900 cursor-pointer"
+                    >
+                      {position}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="lg"
+          onClickHandler={() => {
+            console.log("click");
+          }}
+        >
+          참여하기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ButtonSection;

--- a/src/components/postDetail/infoSection/InfoSection.tsx
+++ b/src/components/postDetail/infoSection/InfoSection.tsx
@@ -1,0 +1,95 @@
+import PositionBadge from "@/components/ui/PositionBadge";
+import TrustGradeBadge from "@/components/ui/TrustGradeBadge";
+import React from "react";
+import Image from "next/image";
+
+const InfoSection = () => {
+  return (
+    <div className="py-14 px-4 grid gap-x-1 grid-cols-2 text-xl font-bold gap-y-6 auto-rows-auto mobile:text-xs mobile:grid-cols-1 mobile:gap-y-0 mobile:py-7">
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">모임 이름</span>
+        <span>trustcrew</span>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">모임 등급</span>
+        <div>
+          <TrustGradeBadge size="sm" text="1등급" color="red" />
+        </div>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800 whitespace-nowrap">모임 주제</span>
+        <span className="truncate">팀프로젝트 매칭 서비스 개발</span>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">시작 예정</span>
+        <span>2023.12.05</span>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">모임 구분</span>
+        <span>프로젝트</span>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">종료 예정</span>
+        <span>2024.01.05</span>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">모집 인원</span>
+        <span>5명</span>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800 whitespace-nowrap">사용 언어</span>
+        <div className="flex gap-1 items-center">
+          <div className="w-10 h-10 mobile:w-8 mobile:h-8">
+            <Image
+              src="/images/javascript.svg"
+              alt="자바스크립트"
+              width={40}
+              height={40}
+              layout="responsive"
+            />
+          </div>
+          <div className="w-10 h-10 mobile:w-8 mobile:h-8">
+            <Image
+              src="/images/typescript.svg"
+              alt="타입스크립트"
+              width={40}
+              height={40}
+            />
+          </div>
+          <div className="w-10 h-10 mobile:w-8 mobile:h-8">
+            <Image
+              src="/images/react.svg"
+              alt="리액트"
+              width={40}
+              height={40}
+            />
+          </div>
+          <div className="w-10 h-10 mobile:w-8 mobile:h-8">
+            <Image src="/images/java.svg" alt="자바" width={40} height={40} />
+          </div>
+          <div className="w-10 h-10 mobile:w-8 mobile:h-8">
+            <Image
+              src="/images/spring.svg"
+              alt="스프링"
+              width={40}
+              height={40}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800">모집 분야</span>
+        <div className="flex gap-1 items-center">
+          <PositionBadge size="xs" text="프론트엔드" />
+          <PositionBadge size="xs" text="백엔드" />
+        </div>
+      </div>
+      <div className="flex gap-5 h-10 items-center">
+        <span className="text-grey800 whitespace-nowrap">연락 수단</span>
+        <span>오픈채팅 / 이메일 / 연락처</span>
+      </div>
+    </div>
+  );
+};
+
+export default InfoSection;

--- a/src/components/postDetail/titleSection/TitleSection.tsx
+++ b/src/components/postDetail/titleSection/TitleSection.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Image from "next/image";
+import BackIcon from "../../../../public/images/pageback.svg";
+
+const TitleSection = () => {
+  return (
+    <div className="flex-col">
+      <Image src={BackIcon} alt="" className="w-8 h-8" />
+      <div className="text-black100 font-bold text-4xl mt-5 mobile:text-3xl mobile:text-center">
+        FE, BE 모집합니다
+      </div>
+      <div className="flex gap-3 items-center mt-8 border-b-2 pb-10 mobile:justify-center mobile:pb-6">
+        <div className="flex items-center gap-2">
+          <div>
+            <img
+              className="inline-block h-8 w-8 rounded-full mobile:h-7 mobile:w-7"
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+              alt=""
+            />
+          </div>
+          <div className="text-lg font-bold mobile:text-base">찐개발자</div>
+        </div>
+        <div>|</div>
+        <div className="text-lg mobile:text-base">2023.11.17</div>
+      </div>
+    </div>
+  );
+};
+
+export default TitleSection;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type ButtonTheme =
+  | "primary"
+  | "primary-hollow"
+  | "disabled"
+  | "disabled-hollow"
+  | "cancel"
+  | "black"
+  | "black-hollow";
+
+export type ButtonSize = "sm" | "md" | "lg" | "xl";
+
+export function makeButtonSize(size: ButtonSize) {
+  let textSize;
+  let px;
+  let py;
+
+  switch (size) {
+    case "sm":
+      textSize = "mobile:text-xs tablet:text-sm";
+      px = "mobile:px-2.5 tablet:px-3";
+      py = "mobile:py-1 tablet:py-1";
+      break;
+    case "md":
+      textSize = "mobile:text-sm tablet:text-md";
+      px = "mobile:px-3 tablet:px-3.5";
+      py = "mobile:py-1 tablet:py-1.5";
+      break;
+    case "lg":
+      textSize = "mobile:text-lg tablet:text-xl";
+      px = "mobile:px-3.5 tablet:px-5";
+      py = "mobile:py-1.5 tablet:py-2";
+      break;
+    case "xl":
+      textSize = "mobile:text-lg tablet:text-xl";
+      px = "mobile:px-4 tablet:px-6";
+      py = "mobile:py-2 tablet:py-3";
+      break;
+    default:
+      textSize = "text-sm";
+      px = "mobile:px-2.5 tablet:px-3.5";
+      py = "mobile:py-1 tablet:py-1.5";
+  }
+
+  return { textSize, px, py };
+}
+
+export function makeButtonColor(theme: ButtonTheme) {
+  let bgColor = "";
+  let textColor = "";
+  let ring = "";
+
+  switch (theme) {
+    case "primary":
+      bgColor = "bg-primary";
+      textColor = "text-white";
+      break;
+    case "primary-hollow":
+      bgColor = "bg-white";
+      textColor = "text-primary";
+      ring = "ring-1 ring-inset ring-primary";
+      break;
+    case "cancel":
+      bgColor = "bg-grey200";
+      textColor = "text-black100";
+      break;
+    case "black":
+      bgColor = "bg-black";
+      textColor = "text-white";
+      break;
+    case "black-hollow":
+      bgColor = "bg-white";
+      textColor = "text-black100";
+      ring = "ring-1 ring-inset ring-black100";
+      break;
+    case "disabled":
+      bgColor = "bg-grey500";
+      textColor = "text-white";
+      break;
+    case "disabled-hollow":
+      bgColor = "bg-white";
+      textColor = "text-grey500";
+      ring = "ring-1 ring-inset ring-grey500";
+      break;
+    default:
+      bgColor = "bg-primary";
+      textColor = "text-white";
+  }
+
+  return { bgColor, textColor, ring };
+}
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: ButtonSize;
+  theme?: ButtonTheme;
+  children: ReactNode;
+  onClickHandler: () => void;
+}
+
+function Button({
+  size = "md",
+  theme = "primary",
+  children,
+  onClickHandler,
+  ...props
+}: ButtonProps) {
+  const { textSize, px, py } = makeButtonSize(size);
+  const { bgColor, textColor, ring } = makeButtonColor(theme);
+
+  return (
+    <button
+      {...props}
+      className={`rounded-full ${bgColor} ${px} ${py} ${textSize} font-semibold ${textColor} shadow-sm ${ring}`}
+      onClick={onClickHandler}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/src/store/PostStateStore.tsx
+++ b/src/store/PostStateStore.tsx
@@ -1,0 +1,9 @@
+import { atom } from "recoil";
+
+type PostPositionStateType = string[];
+
+//게시글마다 필요한 모집직군
+export const PostPositionState = atom<PostPositionStateType>({
+  key: "activeTabState",
+  default: ["프론트엔드", "백엔드"],
+});


### PR DESCRIPTION
## 🎋 작업중인 브랜치 
feature-main

<br/>

## 💡 작업 내용 - #2 
프로젝트 게시글 상세페이지 반응형까지 퍼블리싱 작업


<br/>

## 🔑  변경된 사항 
## 1. 게시글 상세페이지 작업

- ### src/app/post/[id]/page.tsx
-  게시글 상세페이지
- ###  src/component/postDetail/PostDetail.tsx
-  상세페이지 틀 컴포넌트
- ### src/component/postDetail/titleSection/TitleSection.tsx
- 제목, 작성자를 표시해주는 상단부분 컴포넌트
- ### src/component/postDetail/infoSection/InfoSection.tsx
- 프로젝트의 모집조건 등을 표시하는 컴포넌트
- ### src/component/postDetail/bodySection.tsx/BodySection.tsx
- 프로젝트의 글 내용 컴포넌트
- ### src/component/postDetail/buttonSection/ButtonSection.tsx
- 모집중,모집완료 등의 프로젝트 상태표시와 직군을 선택하여 지원하는 버튼이있는 컴포넌트
- ### src/store/PostStateStore.tsx
- PostPositionState 추가(해당 게시글의 모집직군 정보 state)

<br/>

## ✏️  비고 (선택)
상세페이지에 뒤로가기 버튼의 경우 Sunny님이 만드신 공통컴포넌트 사용을 아직 안했는데,
PR후에 main 브렌치 pull 받아서 교체할예정입니다.
해당부분은 추후 기술스택부분 작업분 완료후 PR 올릴때 같이 반영하겠습니다.


<br/>

## ✅  Todo 목록 (선택)

