### PR TITLE
프로젝트 상세 > 크루 상세페이지 상단 프로필 영역 작업

### DIFF
--- a/src/app/project/crews/[userId]/layout.tsx
+++ b/src/app/project/crews/[userId]/layout.tsx
@@ -1,0 +1,18 @@
+import React, {ReactNode} from 'react';
+import Button from "@/components/ui/Button";
+import Link from "next/link";
+
+function ProjectCrewDetailPageLayout({children}: { children: ReactNode }) {
+    return (
+        <section className='w-full flex flex-col items-center'>
+            <section className='w-full px-1'>
+                {children}
+            </section>
+            <section className='my-7'>
+                <Link href='/project/crews'><Button size='lg' theme='primary-hollow'>크루 목록</Button></Link>
+            </section>
+        </section>
+    );
+}
+
+export default ProjectCrewDetailPageLayout;

--- a/src/app/project/crews/[userId]/page.tsx
+++ b/src/app/project/crews/[userId]/page.tsx
@@ -1,0 +1,23 @@
+import React, {Suspense} from 'react';
+import ProfileSection from "@/components/project/crews/detail/ProfileSection";
+import CrewTaskHistory from "@/components/project/crews/detail/CrewTaskHistory";
+
+// todo - params.userId 로 크루 상세정보 조회
+// todo - profile fallback
+function Page({params}:{params:{userId:string;}}) {
+    return (
+        <section className='-mt-14 px-1'>
+            <section className='pc:max-w-[1000px] tablet:max-w-[700px] mx-auto border-b-2 border-gray-200'>
+                <Suspense>
+                    <ProfileSection/>
+                </Suspense>
+            </section>
+            <section>
+                <h3>{params.userId}의 프로젝트 업무 이력</h3>
+                <CrewTaskHistory/>
+            </section>
+        </section>
+    );
+}
+
+export default Page;

--- a/src/components/project/crews/CrewList.tsx
+++ b/src/components/project/crews/CrewList.tsx
@@ -8,42 +8,42 @@ import PositionBadge from "@/components/ui/badge/PositionBadge";
 
 const people = [
     {
-        userId: 'Leslie Alexander',
+        userId: 'Leslie',
         projectMemberAuth: '매니저',
         position: "프론트엔드",
         imageUrl:
             'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
     },
     {
-        userId: 'Michael Foster',
+        userId: 'Michael',
         projectMemberAuth: '부매니저',
         position: "프론트엔드",
         imageUrl:
             'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
     },
     {
-        userId: 'Dries Vincent',
+        userId: 'Dries',
         projectMemberAuth: '구성원',
         position: "프론트엔드",
         imageUrl:
             'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
     },
     {
-        userId: 'Lindsay Walton',
+        userId: 'Lindsay',
         projectMemberAuth: '구성원',
         position: "백엔드",
         imageUrl:
             'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
     },
     {
-        userId: 'Courtney Henry',
+        userId: 'Courtney',
         projectMemberAuth: '구성원',
         position: "백엔드",
         imageUrl:
             'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
     },
     {
-        userId: 'Tom Cook',
+        userId: 'Tom',
         projectMemberAuth: '구성원',
         position: "백엔드",
         imageUrl:
@@ -60,7 +60,7 @@ export default function CrewList() {
         <ul role="list" className="divide-y divide-gray-100">
             {people.map((person) => (
                 <li key={person.userId} className="flex items-center gap-x-6 py-5 cursor-pointer hover:bg-grey000">
-                    <Link href={`/projectmember/${person.userId}/detail`}
+                    <Link href={`/project/crews/${person.userId}`}
                           className="flex items-center min-w-0 tablet:pl-6 mobile:pl-4 tablet:space-x-6 mobile:space-x-4">
                         <Avatar size='xs' src={person.imageUrl} alt={`${person.userId}의 프로필 이미지`}/>
                         <div className="min-w-0 flex items-center tablet:space-x-6 mobile:space-x-4">

--- a/src/components/project/crews/detail/CrewTaskHistory.tsx
+++ b/src/components/project/crews/detail/CrewTaskHistory.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import TaskStatusBadge from "@/components/ui/badge/TaskStatusBadge";
+
+const taskList = [
+    {taskId: '1', contents: 'API 문서 작성', status: '진행중', point: '', pointType: ''},
+    {taskId: '2', contents: 'API 문서 작성', status: '완료', point: '15', pointType: 'plus'},
+    {taskId: '3', contents: 'API 문서 작성', status: '진행중', point: '', pointType: ''},
+    {taskId: '4', contents: 'API 문서 작성', status: '완료', point: '30', pointType: 'minus'},
+    {taskId: '5', contents: 'API 문서 작성', status: '완료', point: '15', pointType: 'plus'},
+    {taskId: '6', contents: 'API 문서 작성', status: '완료', point: '30', pointType: 'minus'},
+    {taskId: '7', contents: 'API 문서 작성', status: '진행중', point: '', pointType: ''},
+]
+
+// todo : 업무 목록 조회
+// todo: 서스펜스 & 스켈레톤 추가
+function CrewTaskHistory() {
+    return (
+        <ul className='w-full'>
+            {
+                taskList.map(
+                    (v) =>
+                        <li
+                            key={v.taskId}
+                            className='flex items-center'
+                        >
+                            <TaskStatusBadge size='sm' text={v.status}/>
+                            <span className='tablet:ml-4 mobile:ml-2 mr-auto'>{v.contents}</span>
+                            <span
+                                className={`${v.pointType === 'minus' ? 'text-[#D22E1D]' : 'text-primary'} font-semibold`}>
+                                {v.contents}
+                            </span>
+                        </li>
+                )
+            }
+        </ul>
+    );
+}
+
+export default CrewTaskHistory;

--- a/src/components/project/crews/detail/LeaveProjectButton.tsx
+++ b/src/components/project/crews/detail/LeaveProjectButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Button from "@/components/ui/Button";
+
+const currentUserId = 'test'
+
+// todo - 현재 로그인 사용자 id
+// 프로젝트 탈퇴 / 강제탈퇴 로직
+function LeaveProjectButton({userId, projectId}: { userId: string; projectId: string }) {
+    return (
+        <Button
+            size='lg'
+            theme='primary-hollow'
+            onClickHandler={() => console.log(userId)}
+        >
+            {userId === currentUserId ? '프로젝트 탈퇴' : '프로젝트 강제 탈퇴'}
+        </Button>
+    );
+}
+
+export default LeaveProjectButton;

--- a/src/components/project/crews/detail/ProfileSection.tsx
+++ b/src/components/project/crews/detail/ProfileSection.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import Avatar from "@/components/ui/Avatar";
+import PositionBadge from "@/components/ui/badge/PositionBadge";
+import ProjectRoleBadge from "@/components/ui/badge/ProjectRoleBadge";
+import Button from "@/components/ui/Button";
+
+const positionList = [
+    {value: 1, name: '프론트엔드'},
+    {value: 2, name: '백엔드'},
+    {value: 3, name: '디자이너'},
+    {value: 4, name: 'IOS'},
+    {value: 5, name: '안드로이드'},
+    {value: 6, name: '데브옵스'}
+];
+
+const techStackList = [
+    {value: 1, name: 'react'},
+    {value: 2, name: 'typeScript'},
+    {value: 3, name: 'javaScript'},
+    {value: 4, name: 'vue'},
+    {value: 5, name: 'nextjs'},
+    {value: 6, name: 'nodejs'},
+    {value: 7, name: 'java'},
+    {value: 8, name: 'spring'},
+    {value: 9, name: 'kotlin'},
+    {value: 10, name: 'nestjs'},
+    {value: 11, name: 'swift'},
+    {value: 12, name: 'flutter'},
+    {value: 13, name: 'figma'},
+];
+
+const testUserInfo = {
+    imageSrc: null,
+    nickname: "Robert Whistable",
+    projectRole:'매니저',
+    projectPosition: positionList[0],
+    techStack: [techStackList[0], techStackList[1], techStackList[5], techStackList[8], techStackList[9]],
+    selfIntroduction: "개발 N년차 웹 프론트엔드 개발자 입니다.",
+    projectCount: 3,
+    trustGrade: 1,
+    trustScore: 1200
+};
+
+function ProfileSection() {
+    return (
+        <div className="flex mobile:flex-col mobile:space-y-6 mobile:mt-4 px-1 py-4 mx-auto items-center justify-center">
+            <section className='mobile:w-full pc:w-[200px] tablet:w-[150px] tablet:mr-10 flex flex-col items-center'>
+                <Avatar size="md" src={testUserInfo.imageSrc} alt="빈 프로필"/>
+                <ul className="mt-1 mb-3 flex flex-col items-center">
+                    <li className="pc:text-2xl tablet:text-[1.3rem] mobile:text-lg font-medium text-greyDarkBlue">{testUserInfo.nickname}</li>
+                </ul>
+                <Button theme='black' size='sm'>프로젝트 탈퇴</Button>
+            </section>
+            <section className='mobile:w-full tablet:h-[200px] mobile:h-[180px] flex flex-col flex-wrap justify-between p-6 mobile:p-4 bg-ground100 rounded-lg'>
+                <div className='pc:h-[50px] tablet:mx-8 flex items-center justify-around mobile:space-x-4'>
+                    <span className='tablet:w-[200px] tablet:text-[1.2rem] font-medium text-geryDarkBlue'>프로젝트 권한</span>
+                    <span className='min-w-[100px] flex justify-center grow-0 mx-auto'>
+                        <ProjectRoleBadge text={testUserInfo.projectRole} size='sm'/>
+                    </span>
+                </div>
+                <div className='pc:h-[50px] tablet:mx-8 flex items-center justify-around mobile:space-x-4'>
+                    <span className='tablet:w-[200px] tablet:text-[1.2rem] font-medium text-geryDarkBlue'>프로젝트 포지션</span>
+                    <span className='min-w-[100px] flex justify-center grow-0 mx-auto'>
+                        <PositionBadge text={testUserInfo.projectPosition.name} size='sm'/>
+                    </span>
+                </div>
+                <div className='pc:h-[50px] tablet:mx-8 flex items-center justify-around mobile:space-x-4'>
+                    <span className='tablet:w-[200px] tablet:text-[1.2rem] font-medium text-geryDarkBlue'>프로젝트 합류일</span>
+                    <span className='min-w-[100px] flex justify-center grow-0 mx-auto text-center tablet:text-lg font-medium text-greyBlue'>2023-10-15</span>
+                </div>
+                <div className='pc:h-[50px] tablet:mx-8 flex items-center justify-around mobile:space-x-4'>
+                    <span className='tablet:w-[200px] tablet:text-[1.2rem] font-medium text-geryDarkBlue'>신뢰점수 획득률</span>
+                    <span className='min-w-[100px] flex justify-center grow-0 mx-auto text-center tablet:text-lg font-medium text-greyBlue'>80%</span>
+                </div>
+            </section>
+        </div>
+    );
+}
+
+export default ProfileSection;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -97,7 +97,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: ButtonSize;
   theme?: ButtonTheme;
   children: ReactNode;
-  onClickHandler: () => void;
+  onClickHandler?: () => void;
 }
 
 function Button({
@@ -114,7 +114,9 @@ function Button({
     <button
       {...props}
       className={`rounded-full ${bgColor} ${px} ${py} ${textSize} font-semibold ${textColor} shadow-sm ${ring}`}
-      onClick={onClickHandler}
+      onClick={ () => {
+        if(typeof onClickHandler === 'function') onClickHandler();
+      }}
     >
       {children}
     </button>

--- a/src/components/ui/badge/ProjectRoleBadge.tsx
+++ b/src/components/ui/badge/ProjectRoleBadge.tsx
@@ -5,13 +5,13 @@ import {BadgeProps} from "@/utils/type";
 function ProjectRoleBadge({size = '', text = ''}: BadgeProps) {
     const {textSize, px, py} = makeBadgeSize(size);
 
-    const bgColor = text === '매니저' ? '#FF513A' : '#FFF9CF';
-    const textColor = text === '매니저' ? '#FFFFFF' : '#7B5C03';
+    const bgColor = text === '매니저' ? 'bg-[#FF513A]' : 'bg-[#FFF9CF]';
+    const textColor = text === '매니저' ? 'text-[#FFFFFF]' : 'text[#7B5C03]';
 
     if(text === '구성원') return null;
     return (
         <span
-            className={`inline-flex items-center rounded-full bg-[${bgColor}] text-[${textColor}] font-medium ${textSize} ${px} ${py}`}>
+            className={`inline-flex items-center rounded-full ${bgColor} ${textColor} font-medium ${textSize} ${px} ${py}`}>
             {text}
         </span>
     );

--- a/src/components/ui/badge/TaskStatusBadge.tsx
+++ b/src/components/ui/badge/TaskStatusBadge.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {BadgeProps} from "@/utils/type";
+import {makeBadgeSize} from "@/utils/common";
+
+function getStatusBadgeColor(text:string){
+    switch(text){
+        case '시작전':
+            return {bgColor:'bg-grey900', textColor:'text-grey000'};
+        case '진행중':
+            return {bgColor:'bg-[#FFF9CF]', textColor:'text-[#7B5C03]'};
+        case '완료':
+            return {bgColor:'bg-[#F1F1F1]', textColor: 'text-[#242D35]'};
+        default:
+            throw Error("Unknown Status Type");
+    }
+}
+
+function TaskStatusBadge({size = '', text = '시작전'}: BadgeProps) {
+
+    const {textSize, px, py} = makeBadgeSize(size);
+
+    const {bgColor, textColor} = getStatusBadgeColor(text);
+
+
+    return (
+        <span
+            className={`inline-flex items-center rounded-full ${bgColor} ${px} ${py} ${textSize} font-medium ${textColor}`}
+        >
+        {text}
+      </span>
+    );
+}
+
+export default TaskStatusBadge;


### PR DESCRIPTION
# 🎋 작업중인 브랜치 
feature-project-crews

<br/>

# 💡 작업 내용 
> 풀 리퀘스트에 대한 간략한 설명을 여기에 입력해주세요

### 1.  크루 상세페이지 라우트 추가
### 2. 크루 상세페이지 상단 프로필 영역 추가
### 3. 크루 상세페이지 하단 업무 히스토리 영역 추가 (작업중)
### 4. 공통 Button 컴포넌트 onClickHandler 선택적으로 추가하도록 수정
### 5. ProjectRoleBadge tailwind.css 에러 수정 

<br/>

# 🔑  변경된 사항 
> 변경된 파일과 그에 대한 간략한 설명을 나열해주세요. 

## 1. 크루 상세페이지 라우트 추가

### - src/app/project/crews/[userId]/page.tsx
  - 크루 상세페이지 렌더링 페이지 
### - src/app/project/crews/[userId]/layout.tsx
   - 크루 상세페이지 layout
### - src/components/project/crews/CrewList.tsx
   - 크루 목록 클릭하면 크루상세페이지로 이동하도록 수정 

<br/>

## 2. 크루 상세페이지 상단 프로필 영역 추가
### - src/components/project/crews/detail/ProfileSection.tsx
   - 상단 프로필 영역 컴포넌트
### - src/components/project/crews/detail/LeaveProjectButton.tsx
   - 프로젝트 탈퇴 버튼 

<br/>

## 3. 크루 상세페이지 하단 업무 히스토리 영역 추가 (작업중)
### - src/components/project/crews/detail/CrewTaskHistory.tsx
   - 업무 히스토리 영역 컴포넌트 
### - src/components/ui/badge/TaskStatusBadge.tsx
   - 업무 상태 뱃지 추가 

<br/>

## 4. 공통 Button 컴포넌트 onClickHandler 선택적으로 추가하도록 수정
### - src/components/ui/Button.tsx
   - Button 컴포넌트 props 중 onClickHandler 를 필수가 아니라 선택적으로 추가할수있도록 수정했습니다 

<br/>

## 5. ProjectRoleBadge tailwind.css 에러 수정 
### - src/components/ui/badge/ProjectRoleBadge.tsx
   - tailwind.css 클래스를 부분적으로만 동적으로 생성하면 css 잘 입혀지지 않는 에러가 있어서 class 통째로 
   동적으로 생성하도록 수정했습니다. 

# ✏️  비고 (선택)
> 다른 리뷰어 또는 팀원에게 전달하고 싶은 추가 정보나 요청사항을 여기에 추가해주세요.


<br/>

# ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
