### PR TITLE
프로젝트 상세 - 알림 목록 조회기능 보완 및 알림 탭 목록 enum 추가

### DIFF
--- a/src/app/api/project/notice/route.ts
+++ b/src/app/api/project/notice/route.ts
@@ -8,11 +8,16 @@ const baseURL = process.env.NEXT_PUBLIC_BACKEND;
  * @param req
  * @constructor
  */
-export async function GET(req:NextRequest){
+export async function GET(req: NextRequest) {
     const {searchParams} = new URL(req.url);
     const projectId = searchParams.get('projectId');
+    const pageIndex = searchParams.get('pageIndex');
+    const itemCount = searchParams.get('itemCount');
 
-    const res = await authApi(`${baseURL}/api/project/${projectId}`, {method:'GET'});
+    const res = await authApi(
+        `${baseURL}/api/project/${projectId}?pageIndex=${pageIndex}&itemCount=${itemCount}`,
+        {method: 'GET'}
+    );
     const data = await res.json();
 
     return NextResponse.json(data);

--- a/src/components/project/notice/NoticeList.tsx
+++ b/src/components/project/notice/NoticeList.tsx
@@ -6,16 +6,17 @@ import {useSuspenseQuery} from "@tanstack/react-query";
 import {useQueryString} from "@/hooks/useQueryString";
 import {getProjectNoticeList} from "@/service/project/notice";
 import CommonPagination from "@/components/ui/CommonPagination";
+import {useRecoilValue} from "recoil";
+import {currentProjectNoticeNavTabSelector} from "@/store/project/notice/ProjectNoticeNavTabStateStore";
 
 
-// todo 1 - 시간마다 체크 안된 전체 알림 목록 조회
-//  - 페이지네이션: 한 페이지에 10 row
-//  - 모집 / 업무 / 크루 / 전체별 api (시간마다 & 요청시 조회)
 const ITEM_COUNT = 10;
 const PAGE_RANGE = 5;
+
 function NoticeList() {
     const projectId = useQueryString('projectId');
     const [pageIndex, setPageIndex] = useState(0);
+    const currentNoticeNavTab = useRecoilValue(currentProjectNoticeNavTabSelector);
 
     // 5초마다 백그라운드에서 알림 목록 refetch
     const {data} = useSuspenseQuery<PageResponseBody<Notice[]>, Error>({
@@ -25,7 +26,7 @@ function NoticeList() {
         refetchIntervalInBackground: true
     });
 
-    const noticeList = data.data.content;
+    const noticeList = data.data.content.filter(v => v.type === currentNoticeNavTab.type);
     const totalCount = data.data.totalPages;
     return (
         <>

--- a/src/components/project/notice/NoticeList.tsx
+++ b/src/components/project/notice/NoticeList.tsx
@@ -1,34 +1,51 @@
 'use client';
-import React from 'react';
+import React, {useState} from 'react';
 import {Notice, PageResponseBody} from "@/utils/type";
 import NoticeItem from "@/components/project/notice/NoticeItem";
 import {useSuspenseQuery} from "@tanstack/react-query";
 import {useQueryString} from "@/hooks/useQueryString";
 import {getProjectNoticeList} from "@/service/project/notice";
+import CommonPagination from "@/components/ui/CommonPagination";
 
 
 // todo 1 - 시간마다 체크 안된 전체 알림 목록 조회
-//  - 특정시간마다 현재 navTab에 매칭되는, 체크 안된 알림목록 조회하는 fetch api 추가 (라우트 핸들러 -> 라우트 핸들러에서 fetch)
 //  - 페이지네이션: 한 페이지에 10 row
 //  - 모집 / 업무 / 크루 / 전체별 api (시간마다 & 요청시 조회)
-
+const ITEM_COUNT = 10;
+const PAGE_RANGE = 5;
 function NoticeList() {
     const projectId = useQueryString('projectId');
-    const {data} = useSuspenseQuery<PageResponseBody<Notice[]>,Error>({
-       queryKey:['noticeList',projectId],
-       queryFn: () => getProjectNoticeList(projectId)
+    const [pageIndex, setPageIndex] = useState(0);
+
+    // 5초마다 백그라운드에서 알림 목록 refetch
+    const {data} = useSuspenseQuery<PageResponseBody<Notice[]>, Error>({
+        queryKey: ['noticeList', projectId],
+        queryFn: () => getProjectNoticeList(projectId, pageIndex, ITEM_COUNT),
+        refetchInterval: 5000,
+        refetchIntervalInBackground: true
     });
 
     const noticeList = data.data.content;
+    const totalCount = data.data.totalPages;
     return (
-        <ul
-            role="list"
-            className="divide-y divide-gray-100 mobile:max-h-[23rem] mobile:overflow-y-auto"
-        >
-            {noticeList.map((item) => (
-                <NoticeItem item={item} key={item.alertId}/>
-            ))}
-        </ul>
+        <>
+            <ul
+                role="list"
+                className="divide-y divide-gray-100 mobile:max-h-[23rem] mobile:overflow-y-auto"
+            >
+                {noticeList.map((item) => (
+                    <NoticeItem item={item} key={item.alertId}/>
+                ))}
+            </ul>
+            <CommonPagination
+                activePage={pageIndex}
+                itemsCountPerPage={ITEM_COUNT}
+                totalItemsCount={totalCount}
+                pageRangeDisplayed={PAGE_RANGE}
+                onChangePageHandler={(pageIndex:number) => setPageIndex(pageIndex)}
+            />
+        </>
+
     );
 }
 

--- a/src/components/project/notice/NoticeModal.tsx
+++ b/src/components/project/notice/NoticeModal.tsx
@@ -3,6 +3,11 @@ import React, {useEffect, useState} from 'react';
 import Modal from "@/components/ui/Modal";
 import NoticeItemDetail from "@/components/project/notice/noticeItemDetail/NoticeItemDetail";
 import {useRecoilValue, useResetRecoilState} from "recoil";
+import {
+    projectNoticeCurrentFormState,
+    projectNoticeModalStateSelector
+} from "@/store/project/notice/ProjectNoticeStateStore";
+import {createPortal} from "react-dom";
 
 function NoticeModal() {
     const {isOpen, title} = useRecoilValue(projectNoticeModalStateSelector);
@@ -50,12 +55,5 @@ function NoticeModal() {
     );
 }
 
-
-import {
-    projectNoticeCurrentFormState,
-    projectNoticeModalStateSelector
-} from "@/store/project/notice/ProjectNoticeStateStore";
-import {createPortal} from "react-dom";
-import {NoticeType} from "@/utils/type";
 
 export default NoticeModal;

--- a/src/components/project/notice/NoticeNavTab.tsx
+++ b/src/components/project/notice/NoticeNavTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 import {useRecoilState, useRecoilValue} from "recoil";
-import React, {MouseEvent, useState} from "react";
-import {NavTabItem, SelectItem} from "@/utils/type";
+import React, {MouseEvent} from "react";
+import {NoticeNavTabItem, SelectItem} from "@/utils/type";
 import {
     currentProjectNoticeNavTabSelector,
     projectNoticeNavTabStateStore
@@ -16,16 +16,36 @@ function classNames(...classes: string[]) {
 
 export default function NoticeNavTab() {
     const [noticeNavTabs, setNoticeNavTabs] = useRecoilState(projectNoticeNavTabStateStore);
-    const [noticeNavSelect, setNoticeNavSelect] = useState<SelectItem | null>({name:'전체',value:'전체'});
     const currentNoticeNavTab = useRecoilValue(currentProjectNoticeNavTabSelector);
 
+    /**
+     * 태블릿/pc nav tab handler
+     * @param target
+     */
     function onClickHandler({target}: MouseEvent<HTMLElement>) {
-        const updatedNavTabs: NavTabItem[] = [];
+        const updatedNavTabs: NoticeNavTabItem[] = [];
 
         [...noticeNavTabs].forEach((v) => {
             updatedNavTabs.push({
                 ...v,
-                current: v.href === (target as HTMLElement).dataset.pathname
+                current: v.type_kor === (target as HTMLElement).textContent
+            });
+        });
+
+        setNoticeNavTabs(updatedNavTabs);
+    }
+
+    /**
+     * 모바일 nav select handler
+     * @param item
+     */
+    function onChangeSelectHandler(item: SelectItem) {
+        const updatedNavTabs: NoticeNavTabItem[] = [];
+
+        [...noticeNavTabs].forEach((v) => {
+            updatedNavTabs.push({
+                ...v,
+                current: v.type_kor === item.name
             });
         });
 
@@ -37,33 +57,38 @@ export default function NoticeNavTab() {
              aria-label="Sidebar">
             <ul role="list"
                 className="mobile:hidden tablet:-mx-2 tablet:space-y-1">
-                {noticeNavTabs.map((item) => (
-                        <li key={item.name}>
-                            <div
-                                key={item.name}
-                                className={classNames(
-                                    item.href === currentNoticeNavTab.href ? 'bg-gray-50 text-primary' : 'text-gray-700 hover:text-primary hover:bg-gray-50',
-                                    'group flex items-center rounded-md p-5 pl-3 text-xl text-center leading-6 font-medium cursor-pointer'
-                                )}
-                                data-pathname={item.href}
-                                onClick={onClickHandler}>
-                                {item.name}
-                            </div>
-                        </li>
-                    )
-                )}
+                {
+                    noticeNavTabs.map((item) => (
+                            <li key={item.type}>
+                                <div
+                                    className={classNames(
+                                        item.type_kor === currentNoticeNavTab.type_kor ? 'bg-gray-50 text-primary' : 'text-gray-700 hover:text-primary hover:bg-gray-50',
+                                        'group flex items-center rounded-md p-5 pl-3 text-xl text-center leading-6 font-medium cursor-pointer'
+                                    )}
+                                    onClick={onClickHandler}>
+                                    {item.type_kor}
+                                </div>
+                            </li>
+                        )
+                    )}
             </ul>
             <div className='mobile:block hidden'>
                 <Select
                     items={
                         noticeNavTabs.map(
                             v => {
-                                return {name: v.name, value: v.name}
+                                return {
+                                    name: v.type_kor,
+                                    value: v.type
+                                }
                             }
                         )}
                     label=''
-                    setValue={setNoticeNavSelect}
-                    value={noticeNavSelect}
+                    setValue={onChangeSelectHandler}
+                    value={{
+                        name: currentNoticeNavTab.type_kor,
+                        value: currentNoticeNavTab.type
+                    }}
                 />
             </div>
         </nav>

--- a/src/service/project/notice.ts
+++ b/src/service/project/notice.ts
@@ -4,7 +4,10 @@ import {request} from "@/service/project/request";
  * 프로젝트 알림 목록 조회
  * @param projectId
  */
-export async function getProjectNoticeList(projectId:string){
-    return await request('GET',`/api/project/notice?projectId=${projectId}`);
+export async function getProjectNoticeList(projectId: string | bigint, pageIndex: number, itemCount: number) {
+    return await request(
+        'GET',
+        `/api/project/notice?projectId=${projectId}&pageIndex=${pageIndex}&itemCount=${itemCount}`
+    );
 }
 

--- a/src/store/project/ProjectNavTabStateStore.tsx
+++ b/src/store/project/ProjectNavTabStateStore.tsx
@@ -1,5 +1,5 @@
 import {atom, selector} from "recoil";
-import {NavTabItem, ProjectNavTabItem} from "@/utils/type";
+import {ProjectNavTabItem} from "@/utils/type";
 
 class ProjectNavItemImpl implements ProjectNavTabItem {
     current: boolean;
@@ -24,7 +24,7 @@ export const projectNavTabState = atom<ProjectNavTabItem[]>({
     ]
 });
 
-export const currentProjectNavTabSelector = selector<NavTabItem | null>({
+export const currentProjectNavTabSelector = selector<ProjectNavTabItem | null>({
     key:'currentProjectNavTabSelector',
     get:({get}) => {
         const navTabs = get(projectNavTabState);

--- a/src/store/project/notice/ProjectNoticeNavTabStateStore.tsx
+++ b/src/store/project/notice/ProjectNoticeNavTabStateStore.tsx
@@ -1,30 +1,32 @@
 import {atom, selector} from "recoil";
-import {NavTabItem} from "@/utils/type";
+import {NoticeNavTabItem, NoticeTypeKey, NoticeTypeValue} from "@/utils/type";
+import {NOTICE_TYPE} from "@/utils/constant";
 
 
-class ProjectNoticeNavTabItem implements NavTabItem {
+class ProjectNoticeNavTabItem implements NoticeNavTabItem {
     current: boolean;
-    href: string;
-    name: string;
+    type: NoticeTypeKey | 'ALL';
+    type_kor: NoticeTypeValue | '전체';
 
-    constructor(current: boolean, href: string, name: string) {
+
+    constructor(current: boolean, type :NoticeTypeKey | 'ALL') {
         this.current = current;
-        this.href = href;
-        this.name = name;
+        this.type = type;
+        this.type_kor = type === 'ALL' ? '전체' : NOTICE_TYPE[type];
     }
 }
 
-export const projectNoticeNavTabStateStore = atom<NavTabItem[]>({
+export const projectNoticeNavTabStateStore = atom<NoticeNavTabItem[]>({
     key: 'projectNoticeNavTabState',
     default: [
-        new ProjectNoticeNavTabItem(true, '/project/notice','전체'),
-        new ProjectNoticeNavTabItem(false, '/project/notice/recruit','모집'),
-        new ProjectNoticeNavTabItem(false, '/project/notice/task','업무'),
-        new ProjectNoticeNavTabItem(false, '/project/notice/crew','크루')
+        new ProjectNoticeNavTabItem(true,'ALL'),
+        new ProjectNoticeNavTabItem(false, 'RECRUIT'),
+        new ProjectNoticeNavTabItem(false, 'WORK'),
+        new ProjectNoticeNavTabItem(false, 'CREW')
     ]
 });
 
-export const currentProjectNoticeNavTabSelector = selector<NavTabItem>({
+export const currentProjectNoticeNavTabSelector = selector<NoticeNavTabItem>({
     key:'currentProjectNoticeNavTabSelector',
     get:({get}) => {
         const navTabs = get(projectNoticeNavTabStateStore);

--- a/src/store/project/notice/ProjectNoticeStateStore.tsx
+++ b/src/store/project/notice/ProjectNoticeStateStore.tsx
@@ -1,12 +1,12 @@
 import {atom, selector} from "recoil";
-import {Notice, NoticeType, Position} from "@/utils/type";
+import {Notice, NoticeTypeKey, Position} from "@/utils/type";
 
 
 /**
  * 크루 알림 form 상태
  */
 export interface ProjectNoticeCrewFormState extends Notice {
-    type: NoticeType;
+    type: NoticeTypeKey;
     alertId: bigint;
     checkUserId: bigint;
     sendUserId: bigint;
@@ -28,7 +28,7 @@ export class ProjectNoticeCrewForm implements ProjectNoticeCrewFormState {
     position: Position | null;
     projectId: bigint;
     sendUserId: bigint;
-    type: NoticeType;
+    type: NoticeTypeKey;
     updateDate: string;
     workId: bigint | null;
 
@@ -80,7 +80,7 @@ export class ProjectNoticeTaskForm implements ProjectNoticeTaskFormState {
     position: Position | null;
     projectId: bigint;
     sendUserId: bigint;
-    type: NoticeType;
+    type: NoticeTypeKey;
     updateDate: string;
     workId: bigint | null;
 
@@ -133,7 +133,7 @@ export class ProjectNoticeRecruitForm implements ProjectNoticeRecruitFormState {
     position: Position | null;
     projectId: bigint;
     sendUserId: bigint;
-    type: NoticeType;
+    type: NoticeTypeKey;
     updateDate: string;
     workId: bigint | null;
 

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -2,3 +2,13 @@ export enum CREW_STATUS {
     PARTICIPATING = '참여중',
     WITHDRAWLING = '탈퇴 진행중'
 }
+
+export const NOTICE_TYPE = {
+    RECRUIT: '모집',
+    WORK: '업무',
+    ADD: '크루',
+    WITHDRAWL: '크루',
+    FORCEWITHDRAWL: '크루',
+    CREW: '크루'
+} as const;
+

--- a/src/utils/type.d.ts
+++ b/src/utils/type.d.ts
@@ -1,6 +1,6 @@
 import {CookieValueTypes} from "cookies-next";
 import {MilestoneStatusName} from "@/store/project/task/MilestoneStateStore";
-import {CREW_STATUS} from "@/utils/constant";
+import {CREW_STATUS, NOTICE_TYPE} from "@/utils/constant";
 
 export type DropDownItem = {
     name: string;
@@ -298,19 +298,9 @@ export interface SnackbarState {
     duration?: number;
 }
 
-/**
- * ADD - 크루 추가됨
- * WITHDRAWL - 크루 탈퇴
- * FORCEWITHDRAWL - 크루 강제 탈퇴
- */
-export type CrewNoticeType = 'ADD' | 'WITHDRAWL' | 'FORCEWITHDRAWL';
+export type NoticeTypeKey = keyof typeof NOTICE_TYPE;
 
-/**
- * RECRUIT - 모집
- * WORK - 업무
- * CrewNoticeType - 크루(크루추가/탈퇴/강제탈퇴)
- */
-export type NoticeType = 'RECRUIT' | 'WORK' | CrewNoticeType;
+export type NoticeTypeValue = typeof NOTICE_TYPE[NoticeTypeKey];
 
 export interface Notice {
     alertId: bigint;
@@ -321,7 +311,7 @@ export interface Notice {
     milestoneId: bigint | null;
     position: Position | null;
     content: string;
-    type: NoticeType;
+    type: NoticeTypeKey;
     createDate: string;
     updateDate: string;
 }

--- a/src/utils/type.d.ts
+++ b/src/utils/type.d.ts
@@ -12,13 +12,13 @@ export interface DropDownProps {
     items: DropDownItems[];
 }
 
-export interface NavTabItem {
-    name: string;
-    href: string;
+export interface NoticeNavTabItem {
+    type: NoticeTypeKey | 'ALL';
+    type_kor: NoticeTypeValue | '전체';
     current: boolean;
 }
 
-export interface ProjectNavTabItem extends NavTabItem {
+export interface ProjectNavTabItem {
     name: string;
     href: string;
     current: boolean;


### PR DESCRIPTION
# 🎋 작업중인 브랜치 
feature-service-project

<br/>

# 💡 작업 내용 
> 풀 리퀘스트에 대한 간략한 설명을 여기에 입력해주세요

### 1. 알림 목록 pagination & 실시간 refetch 추가 
### 2. 알림 nav탭 목록 enum으로 생성, 알림 nav탭 상태관리에 반영 

<br/>

# 🔑  변경된 사항 
> 변경된 파일과 그에 대한 간략한 설명을 나열해주세요. 

## 1. 알림 목록 pagination & 실시간 refetch 추가 
### e9d2a4feee4f7f62447e459c30cea73f7dd0fabb
   - 5초마다 백그라운드에서 알림목록 조회해오도록 기존 알림 목록 조회 쿼리에 refetchInterval, refetchIntervalInBackground 옵션 추가했습니다 

<br/>

## 2. 알림 nav탭 목록 const enum으로 생성, enum의 key, value 타입 생성
### 179f9c8654543aca4c45261b754c06a2e0336402, e08d9fe784e373ee80e394a66fafc32226ab06c8
   - nav탭 목록같은 경우 key-value pair의 상수로 관리해주는 것이 좋을 것 같아서 enum으로 생성하고, nav탭 상태 관리에도 반영했습니다.

### ad2224078be774cdf999e64bba6d8c0da7260205
   - 프로젝트 내 메인 nav탭은 url 주소 기반으로 동작하기때문에 관련 인터페이스 분리했습니다. 
<br/>

## 3.

<br/>

# ✏️  비고 (선택)
> 다른 리뷰어 또는 팀원에게 전달하고 싶은 추가 정보나 요청사항을 여기에 추가해주세요.

진행중 #104 

<br/>

# ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
