### PR TITLE
프로필 이미지 삭제 후 저장 시 S3 에서도 삭제하도록 api 연결

### DIFF
--- a/src/app/api/user/[slug]/route.ts
+++ b/src/app/api/user/[slug]/route.ts
@@ -28,3 +28,18 @@ export async function GET(
   const data = await res.json();
   return NextResponse.json(data);
 }
+
+export async function DELETE(
+  _: NextRequest,
+  { params }: { params: { slug: string } }
+) {
+  let res: Response;
+  if (params.slug === "profile-img") {
+    res = await authApi("/api/user/me/profile-img", { method: "DELETE" });
+  } else {
+    throw Error("Unknown Api Route");
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/src/service/user/user.ts
+++ b/src/service/user/user.ts
@@ -1,5 +1,3 @@
-import authApi from "@/utils/authApi";
-
 const publicURL = process.env.NEXT_PUBLIC_URL;
 
 export interface updateUserInfo {
@@ -49,18 +47,6 @@ export const updateUser = async (
   return response.json();
 };
 
-export const updateUserProfileImg = async (file: File) => {
-  const response = await authApi("/api/user/me/profile-img", {
-    method: "POST",
-    body: file,
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
-  });
-
-  return response.json();
-};
-
 export const getUserProjectHistory = async (pageNumber: number) => {
   const response = await fetch(
     `${publicURL}/api/user/history?pageNumber=${pageNumber}`
@@ -70,5 +56,10 @@ export const getUserProjectHistory = async (pageNumber: number) => {
 
 export const getTrustGradeListByUser = async () => {
   const response = await fetch(`${publicURL}/api/user/trust-grade`);
+  return response.json();
+};
+
+export const deleteProfileImage = async () => {
+  const response = await fetch(`${publicURL}/api/user/profile-img`, { method: "DELETE" });
   return response.json();
 };


### PR DESCRIPTION
# 🎋 작업중인 브랜치 
featuser-service-user

<br/>

# 💡 작업 내용 
> 풀 리퀘스트에 대한 간략한 설명을 여기에 입력해주세요

### 1. 프로필 이미지 삭제 후 저장 시 S3 에서도 삭제하도록 api 연결

<br/>

# 🔑  변경된 사항 
> 변경된 파일과 그에 대한 간략한 설명을 나열해주세요. 

## 1. 프로필 이미지 삭제 후 저장 시 S3 에서도 삭제하도록 api 연결 & 필요없는 updateUserProfileImg api 삭제
8272bea1ea9b3200c70fa33a130abac4100a39c1
<br/>

# ✏️  비고 (선택)
> 다른 리뷰어 또는 팀원에게 전달하고 싶은 추가 정보나 요청사항을 여기에 추가해주세요.

진행중 #121 
<br/>

# ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
